### PR TITLE
Improvement(2246): Font styles for Paragraph, Heading and Blockquote

### DIFF
--- a/src/components/typography/Blockquote/blockquote.scss
+++ b/src/components/typography/Blockquote/blockquote.scss
@@ -1,9 +1,14 @@
+@import '../../../_mixins';
+
 .alt-blockquote {
   display: flex;
   position: relative;
   flex-direction: column;
-  padding: calc(var(--gap) * 2) calc(var(--gap) * 6);
-  border-radius: 8px;
+  padding: 8px 24px;
+  margin: 0;
+  border-radius: 12px;
+
+  @include useFontSize(body);
 
   &:before {
     position: absolute;
@@ -13,8 +18,8 @@
     bottom: var(--gap);
     height: calc(100% - var(--gap) * 2);
     width: 4px;
-    border-radius: 4px;
-    background-color: var(--dividerColor);
+    border-radius: 6px;
+    background-color: var(--borderColor);
     transition: height 0.3s ease;
   }
 }
@@ -25,8 +30,10 @@
 }
 
 .alt-blockquote__author {
-  font-size: 12px;
   color: var(--secondaryTextColor);
+  font-style: italic;
+
+  @include useFontSize(body, Small);
 }
 
 .altrone--dark {

--- a/src/components/typography/Heading/Heading.tsx
+++ b/src/components/typography/Heading/Heading.tsx
@@ -2,6 +2,7 @@ import {WithAltroneOffsets, WithoutDefaultOffsets} from "../../../types";
 import {memo} from "react";
 import {Box} from "../../containers/Box";
 import './heading.scss'
+import clsx from "clsx";
 
 interface HeadingProps extends WithoutDefaultOffsets, WithAltroneOffsets {
   level?: 1 | 2 | 3 | 4 | 5 | 6
@@ -12,6 +13,7 @@ const Heading = ({ children, level = 1, ...props }: HeadingProps) => {
 
   return <Box
     tagName={tagName}
+    className={clsx('alt-heading', `alt-heading--level-${level}`, props.className)}
     {...props}
   >
     {children}

--- a/src/components/typography/Heading/heading.scss
+++ b/src/components/typography/Heading/heading.scss
@@ -1,28 +1,30 @@
-h1, h2, h3, h4, h5, h6 {
-  line-height: 1.2;
-  margin: 0.75em 0 0;
+@import '../../../_mixins';
+
+.alt-heading {
+  margin: 0;
+  line-height: 1.25;
 }
 
-h1 {
-  font-size: 40px;
+.alt-heading--level-1 {
+  @include useFontSize(headline, Large);
 }
 
-h2 {
-  font-size: 32px;
+.alt-heading--level-2 {
+  @include useFontSize(headline);
 }
 
-h3 {
-  font-size: 26px;
+.alt-heading--level-3 {
+  @include useFontSize(headline, Small);
 }
 
-h4 {
-  font-size: 22px;
+.alt-heading--level-4 {
+  @include useFontSize(title, Large);
 }
 
-h5 {
-  font-size: 18px;
+.alt-heading--level-5 {
+  @include useFontSize(title);
 }
 
-h6 {
-  font-size: 16px;
+.alt-heading--level-6 {
+  @include useFontSize(title, Small);
 }

--- a/src/components/typography/Paragraph/paragraph.scss
+++ b/src/components/typography/Paragraph/paragraph.scss
@@ -1,3 +1,6 @@
+@import '../../../_mixins';
+
 .alt-paragraph {
   margin: 1em 0;
+  @include useFontSize(body);
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -99,21 +99,21 @@
 
   --titleLargeFontSize: 22px;
   --titleLageLineHeight: 28px;
-  --titleLargeFontWeight: 400;
+  --titleLargeFontWeight: 500;
 
   /* ---- */
 
   --headlineSmallFontSize: 24px;
   --headlineSmallLineHeight: 32px;
-  --headlineSmallFontWeight: 400;
+  --headlineSmallFontWeight: 600;
 
   --headlineFontSize: 28px;
   --headlineLineHeight: 36px;
-  --headlineFontWeight: 400;
+  --headlineFontWeight: 600;
 
   --headlineLargeFontSize: 32px;
   --headlineLageLineHeight: 40px;
-  --headlineLargeFontWeight: 400;
+  --headlineLargeFontWeight: 700;
 
   /* ---- */
 


### PR DESCRIPTION
- updated font-size and font-weight for Paragraph, Heading and Blockquote
- updated styles of left line in Blockquote
- added class-selectors for Heading instead of tag-selectors
- updated values of following CSS variables: --titleLargeFontWeight, --headlineSmallFontWeight, --headlineFontWeight, --headlineLargeFontWeight